### PR TITLE
Replace camptocamp repo with puppetlabs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git://github.com/puppetlabs/puppetlabs-apache
 [submodule "puppet/modules/apt"]
 	path = puppet/modules/apt
-	url = git://github.com/camptocamp/puppet-apt
+	url = git://github.com/puppetlabs/puppetlabs-apt
 [submodule "puppet/modules/augeas"]
 	path = puppet/modules/augeas
 	url = git://github.com/camptocamp/puppet-augeas


### PR DESCRIPTION
puppet-apt is no longer available on at the designated source. Perhaps puppetlabs-apt will work.